### PR TITLE
[MapView] Fix initialRegion

### DIFF
--- a/lib/components/MapView.js
+++ b/lib/components/MapView.js
@@ -462,13 +462,10 @@ class MapView extends React.Component {
     const { layout } = e.nativeEvent;
     if (!layout.width || !layout.height) return;
     if (this.state.isReady && !this.__layoutCalled) {
-      const { region, initialRegion } = this.props;
+      const region = this.props.region || this.props.initialRegion;
       if (region) {
         this.__layoutCalled = true;
         this.map.setNativeProps({ region });
-      } else if (initialRegion) {
-        this.__layoutCalled = true;
-        this.map.setNativeProps({ initialRegion });
       }
     }
     if (this.props.onLayout) {


### PR DESCRIPTION
Previous commit introduced a bug where initialRegion would not apply to
map.

Reverts JS changes made in e543e7247b17274f4f260ee5cc7dee75deeff0e9